### PR TITLE
bring back small undef

### DIFF
--- a/bzlib.h
+++ b/bzlib.h
@@ -76,6 +76,10 @@ typedef
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #   include <windows.h>
+#   ifdef small
+      /* windows.h define small to char */
+#      undef small
+#   endif
 #   include <io.h>
 #   include <sys/utime.h>
 #   define fdopen		_fdopen


### PR DESCRIPTION
undef for small was removed when converting to cmake build system, which breaks compile on windows if bzlib.h is included after windows.h